### PR TITLE
Updated to work on Windows Native Python

### DIFF
--- a/scrapy_wayback_machine/__init__.py
+++ b/scrapy_wayback_machine/__init__.py
@@ -2,6 +2,8 @@ import json
 from datetime import datetime, timezone
 from urllib.request import pathname2url
 
+import urllib
+
 from scrapy import Request
 from scrapy.http import Response
 from scrapy.exceptions import NotConfigured, IgnoreRequest
@@ -88,7 +90,7 @@ class WaybackMachineMiddleware:
         return response
 
     def build_cdx_request(self, request):
-        cdx_url = self.cdx_url_template.format(url=pathname2url(request.url))
+        cdx_url = self.cdx_url_template.format(url=urllib.parse.quote_plus(request.url))
         cdx_request = Request(cdx_url)
         cdx_request.meta['wayback_machine_original_request'] = request
         cdx_request.meta['wayback_machine_cdx_request'] = True


### PR DESCRIPTION
I haven't confirmed it still works natively on not windows, but this fix is pulled from here:
https://github.com/vulnersCom/getsploit/commit/8531ff5989a1d2c2ab65546e32b6f8a31a20a48d

Which was the error I was getting trying to use the WayBackMachine Scraper (cmd line tool)

I ended up having to pull down both in order to get it working, and this was the eventual fix that got it working.  

You may be able to remove the reference above the new import for urllib, that imports the pathname2url, I didn't try it because the point of the whole thing was to scrape a wayback machine page, more than to create a tool for such.

Thank you for the tool though XD.  It's much appreciated, even with having to debug it to get it working on windows! XD XD