### PR TITLE
Add fallback pathname2url import for Python 2

### DIFF
--- a/scrapy_wayback_machine/__init__.py
+++ b/scrapy_wayback_machine/__init__.py
@@ -1,7 +1,10 @@
 import os
 import json
 from datetime import datetime, timezone
-from urllib.request import pathname2url
+try:
+    from urllib.request import pathname2url
+except ImportError:
+    from urllib import pathname2url
 
 from scrapy import Request
 from scrapy.http import Response

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = description + \
 
 setup(
     name='scrapy-wayback-machine',
-    version='1.0.1',
+    version='1.0.2',
     author='Evan Sangaline',
     author_email='evan@intoli.com',
     description=description,


### PR DESCRIPTION
This method was located in a different module in Python 2. This PR catches the import error, and falls back to the Python 2 location.

Closes sangaline/wayback-machine-scraper#12
