### PR TITLE
Fix URL snapshot template

### DIFF
--- a/scrapy_wayback_machine/__init__.py
+++ b/scrapy_wayback_machine/__init__.py
@@ -16,7 +16,7 @@ class UnhandledIgnoreRequest(IgnoreRequest):
 class WaybackMachineMiddleware:
     cdx_url_template = ('https://web.archive.org/cdx/search/cdx?url={url}'
                     '&output=json&fl=timestamp,original,statuscode,digest')
-    snapshot_url_template = 'https://web.archive.org/web/{timestamp}/{original}'
+    snapshot_url_template = 'https://web.archive.org/web/{timestamp}id_/{original}'
     robots_txt = 'https://web.archive.org/robots.txt'
     timestamp_format = '%Y%m%d%H%M%S'
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = description + \
 
 setup(
     name='scrapy-wayback-machine',
-    version='1.0.2',
+    version='1.0.3',
     author='Evan Sangaline',
     author_email='evan@intoli.com',
     description=description,


### PR DESCRIPTION
#4 switched over the snapshot URL template to use `https` URLs, but also removed the `id_` suffix to the timestamp that is necessary to return the original raw snapshot instead of the version with the URLs rewritten to point to their archived copies ([details](https://archive.org/post/1044859/how-do-i-retrieve-the-original-form-of-a-page-from-the-wayback-machine)). This led to issues such as [this StackOverflow question](https://stackoverflow.com/questions/66830537/scraping-the-wayback-machine-with-scrapy-s-crawlspider-and-the-scrapy-wayback-m?sem=2). This PR fixes the snapshot template.
