### PR TITLE
Fix broken API with new Scrapy versions

### DIFF
--- a/scrapy_wayback_machine/__init__.py
+++ b/scrapy_wayback_machine/__init__.py
@@ -80,7 +80,7 @@ class WaybackMachineMiddleware:
 
             # schedule all of the snapshots
             for snapshot_request in snapshot_requests:
-                self.crawler.engine.schedule(snapshot_request, spider)
+                self.crawler.engine.crawl(snapshot_request)
 
             # abort this request
             raise UnhandledIgnoreRequest


### PR DESCRIPTION
schedule() was deprecated and has been removed - https://github.com/scrapy/scrapy/issues/542#issuecomment-32621164
Swapping it for crawl() seems to work.